### PR TITLE
Use separate difference accounts for credit cards (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,7 @@ account in that currency):
 1. Click the **Add Account** button
 2. Choose **Unlinked**
 3. In the **Add Account** dialog, enter:
-   * **Account type:**: one of the **Budget** account types (such as
-     **Cash**)
+   * **Account type:**: **Checking**
    * **Nickname:** must contain a "tag" with the three-letter currency code
      followed by a space and `DIFFERENCE`, all in angle brackets (e.g. `<EUR
      DIFFERENCE>` for Euros)
@@ -172,13 +171,21 @@ account in that currency):
 
    <img src="doc/images/add_budget_account_screenshot.png" alt="[add budget account screenshot]" width="477">
 
-If you have foreign currency **tracking** accounts, you must do also create a
+If you have foreign currency **credit** accounts, you must also create a
+separate difference account for those (so that YNAB's special credit handling
+applies to the converted amounts too).  Follow the same instructions as above,
+but choose account type **Credit Card** instead.  You should add additional
+text to the nickname before or after the "tag" to differentiate it from the
+debit difference account, just make sure the extra text is outside the angle
+brackets (for example, `<EUR DIFFERENCE> Credit`).
+
+If you have foreign currency **tracking** accounts, you must also create a
 separate difference account for those (so that your worth in each is correct).
-Follow the same instructions as above, but choose a **Tracking** account type
-instead, such as **Asset (e.g. Investment)**.  You can add additional text to
-the nickname before or after the "tag" to differentiate it from the budget
-difference account, just make sure the extra text is outside the angle brackets
-(for example, `<EUR DIFFERENCE> Tracking`).
+Follow the same instructions as above, but choose account type **Asset (e.g.
+Investment)** instead.  You can should additional text to the nickname before
+or after the "tag" to differentiate it from the budget difference account, just
+make sure the extra text is outside the angle brackets (for example, `<EUR
+DIFFERENCE> Tracking`).
 
 Finally, create a budget category for foreign currency balance adjustments due
 to exchange rate fluctuations.  You can name this anything you want, for

--- a/migrations/2019-12-03-115001_add_difference_transactions_is_credit_card/down.sql
+++ b/migrations/2019-12-03-115001_add_difference_transactions_is_credit_card/down.sql
@@ -1,0 +1,31 @@
+ALTER TABLE difference_transactions RENAME TO new_difference_transactions_20191203;
+
+CREATE TABLE difference_transactions (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  budget_id INT NOT NULL,
+  foreign_ynab_transaction_id TEXT NOT NULL,
+  difference_ynab_transaction_id TEXT NOT NULL,
+  difference_amount_milliunits BIGINT NOT NULL,
+  difference_currency_code TEXT NOT NULL,
+  difference_is_tracking INTEGER NOT NULL,
+  transfer_currency_code TEXT,
+  transfer_is_tracking INTEGER,
+  UNIQUE(budget_id, foreign_ynab_transaction_id),
+  UNIQUE(budget_id, difference_ynab_transaction_id),
+  FOREIGN KEY(budget_id) REFERENCES budgets(id)
+);
+
+INSERT INTO difference_transactions
+SELECT
+  id,
+  budget_id,
+  foreign_ynab_transaction_id,
+  difference_ynab_transaction_id,
+  difference_amount_milliunits,
+  difference_currency_code,
+  difference_is_tracking,
+  transfer_currency_code,
+  transfer_is_tracking
+FROM new_difference_transactions_20191203;
+
+DROP TABLE new_difference_transactions_20191203;

--- a/migrations/2019-12-03-115001_add_difference_transactions_is_credit_card/up.sql
+++ b/migrations/2019-12-03-115001_add_difference_transactions_is_credit_card/up.sql
@@ -1,0 +1,39 @@
+ALTER TABLE difference_transactions RENAME TO old_difference_transactions_20191203;
+
+CREATE TABLE difference_transactions (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  budget_id INT NOT NULL,
+  foreign_ynab_transaction_id TEXT NOT NULL,
+  difference_ynab_transaction_id TEXT NOT NULL,
+  difference_amount_milliunits BIGINT NOT NULL,
+  difference_currency_code TEXT NOT NULL,
+  difference_is_credit INTEGER NOT NULL,
+  difference_is_tracking INTEGER NOT NULL,
+  transfer_currency_code TEXT,
+  transfer_is_credit INTEGER,
+  transfer_is_tracking INTEGER,
+  UNIQUE(budget_id, foreign_ynab_transaction_id),
+  UNIQUE(budget_id, difference_ynab_transaction_id),
+  FOREIGN KEY(budget_id) REFERENCES budgets(id)
+);
+
+INSERT INTO difference_transactions
+SELECT
+  id,
+  budget_id,
+  foreign_ynab_transaction_id,
+  difference_ynab_transaction_id,
+  difference_amount_milliunits,
+  difference_currency_code,
+  0,
+  difference_is_tracking,
+  transfer_currency_code,
+  NULL,
+  transfer_is_tracking
+FROM old_difference_transactions_20191203;
+
+UPDATE difference_transactions
+SET transfer_is_credit = 0
+WHERE transfer_currency_code IS NOT NULL;
+
+DROP TABLE old_difference_transactions_20191203;

--- a/migrations/2019-12-26-143248_difference_transaction_account_class/down.sql
+++ b/migrations/2019-12-26-143248_difference_transaction_account_class/down.sql
@@ -1,0 +1,51 @@
+ALTER TABLE difference_transactions RENAME TO new_difference_transactions_20191226;
+
+CREATE TABLE difference_transactions (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  budget_id INT NOT NULL,
+  foreign_ynab_transaction_id TEXT NOT NULL,
+  difference_ynab_transaction_id TEXT NOT NULL,
+  difference_amount_milliunits BIGINT NOT NULL,
+  difference_currency_code TEXT NOT NULL,
+  difference_is_credit INTEGER NOT NULL,
+  difference_is_tracking INTEGER NOT NULL,
+  transfer_currency_code TEXT,
+  transfer_is_credit INTEGER,
+  transfer_is_tracking INTEGER,
+  UNIQUE(budget_id, foreign_ynab_transaction_id),
+  UNIQUE(budget_id, difference_ynab_transaction_id),
+  FOREIGN KEY(budget_id) REFERENCES budgets(id)
+);
+
+INSERT INTO difference_transactions
+SELECT
+  id,
+  budget_id,
+  foreign_ynab_transaction_id,
+  difference_ynab_transaction_id,
+  difference_amount_milliunits,
+  difference_currency_code,
+  0,
+  0,
+  transfer_currency_code,
+  NULL,
+  NULL
+FROM new_difference_transactions_20191226;
+
+UPDATE difference_transactions
+SET difference_is_tracking = 1
+WHERE id IN (SELECT id FROM new_difference_transactions_20191226 WHERE difference_account_class = 'T');
+
+UPDATE difference_transactions
+SET difference_is_credit = 1
+WHERE id IN (SELECT id FROM new_difference_transactions_20191226 WHERE difference_account_class = 'C');
+
+UPDATE difference_transactions
+SET transfer_is_tracking = 1
+WHERE id IN (SELECT id FROM new_difference_transactions_20191226 WHERE transfer_account_class = 'T');
+
+UPDATE difference_transactions
+SET transfer_is_credit = 1
+WHERE id IN (SELECT id FROM new_difference_transactions_20191226 WHERE transfer_account_class = 'C');
+
+DROP TABLE new_difference_transactions_20191226;

--- a/migrations/2019-12-26-143248_difference_transaction_account_class/up.sql
+++ b/migrations/2019-12-26-143248_difference_transaction_account_class/up.sql
@@ -1,0 +1,51 @@
+ALTER TABLE difference_transactions RENAME TO old_difference_transactions_20191226;
+
+CREATE TABLE difference_transactions (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  budget_id INT NOT NULL,
+  foreign_ynab_transaction_id TEXT NOT NULL,
+  difference_ynab_transaction_id TEXT NOT NULL,
+  difference_amount_milliunits BIGINT NOT NULL,
+  difference_currency_code TEXT NOT NULL,
+  difference_account_class TEXT NOT NULL,
+  transfer_currency_code TEXT,
+  transfer_account_class TEXT,
+  UNIQUE(budget_id, foreign_ynab_transaction_id),
+  UNIQUE(budget_id, difference_ynab_transaction_id),
+  FOREIGN KEY(budget_id) REFERENCES budgets(id)
+);
+
+INSERT INTO difference_transactions
+SELECT
+  id,
+  budget_id,
+  foreign_ynab_transaction_id,
+  difference_ynab_transaction_id,
+  difference_amount_milliunits,
+  difference_currency_code,
+  'D',
+  transfer_currency_code,
+  NULL
+FROM old_difference_transactions_20191226;
+
+UPDATE difference_transactions
+SET difference_account_class = 'T'
+WHERE id IN (SELECT id FROM old_difference_transactions_20191226 WHERE difference_is_tracking = 1);
+
+UPDATE difference_transactions
+SET difference_account_class = 'C'
+WHERE id IN (SELECT id FROM old_difference_transactions_20191226 WHERE difference_is_credit = 1);
+
+UPDATE difference_transactions
+SET transfer_account_class = 'D'
+WHERE id IN (SELECT id FROM old_difference_transactions_20191226 WHERE transfer_is_tracking = 0 OR transfer_is_credit = 0);
+
+UPDATE difference_transactions
+SET transfer_account_class = 'T'
+WHERE id IN (SELECT id FROM old_difference_transactions_20191226 WHERE transfer_is_tracking = 1);
+
+UPDATE difference_transactions
+SET transfer_account_class = 'C'
+WHERE id IN (SELECT id FROM old_difference_transactions_20191226 WHERE transfer_is_credit = 1);
+
+DROP TABLE old_difference_transactions_20191226;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,6 @@
 use log::debug;
-use std::env;
 use std::ffi::OsStr;
-use std::result;
-use std::str;
-use std::string;
+use std::{env, result, str, string};
 
 use crate::constants::*;
 use crate::currency_converter_client::*;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,9 +45,5 @@ lazy_static! {
 }
 
 pub fn format_adjustment_payee_name(key: DifferenceKey) -> String {
-    format!(
-        "Exchange Rate Adjustment <{}{}>",
-        key.currency,
-        if key.is_tracking { " TRACKING" } else { "" }
-    )
+    format!("Exchange Rate Adjustment <{}>", key.currency,)
 }

--- a/src/foreign_transactions_processor.rs
+++ b/src/foreign_transactions_processor.rs
@@ -314,7 +314,9 @@ impl<'a> ForeignTransactionsProcessor<'a> {
                 amount: Milliunits::zero(),
                 memo: format!(
                     "<{}DELETED{}>{}",
-                    DIFFERENCE_MEMO_TAG_PREFIX, foreign_data.difference_memo_tag_suffix, difference_memo_suffix
+                    DIFFERENCE_MEMO_TAG_PREFIX,
+                    foreign_data.difference_memo_tag_suffix,
+                    difference_memo_suffix
                 ),
                 category_id: &None,
                 category_name: None,
@@ -348,7 +350,8 @@ impl<'a> ForeignTransactionsProcessor<'a> {
                 memo: format!(
                     "<{}MOVED TO LOCAL CURRENCY ACCOUNT{}>{}",
                     DIFFERENCE_MEMO_TAG_PREFIX,
-                    foreign_data.difference_memo_tag_suffix, difference_memo_suffix
+                    foreign_data.difference_memo_tag_suffix,
+                    difference_memo_suffix
                 ),
                 category_id: &None,
                 category_name: None,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -16,9 +16,9 @@ table! {
         difference_ynab_transaction_id -> Text,
         difference_amount_milliunits -> BigInt,
         difference_currency_code -> Text,
-        difference_is_tracking -> Integer,
+        difference_account_class -> Text,
         transfer_currency_code -> Nullable<Text>,
-        transfer_is_tracking -> Nullable<Integer>,
+        transfer_account_class -> Nullable<Text>,
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,7 @@
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::{Decimal, RoundingStrategy};
 use std::borrow::Cow;
-use std::fmt;
-use std::ops;
+use std::{fmt, ops};
 
 use crate::errors::*;
 
@@ -35,7 +34,14 @@ pub struct YnabAccountId<'a> {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DifferenceKey {
     pub currency: CurrencyCode,
-    pub is_tracking: bool,
+    pub account_class: AccountClass,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum AccountClass {
+    Debit,
+    Credit,
+    Tracking,
 }
 
 impl CurrencyCode {
@@ -276,25 +282,30 @@ impl<'a> fmt::Display for YnabAccountId<'a> {
 }
 
 impl DifferenceKey {
-    pub fn new(currency: CurrencyCode, is_tracking: bool) -> DifferenceKey {
+    pub fn new(currency: CurrencyCode, account_class: AccountClass) -> DifferenceKey {
         DifferenceKey {
             currency,
-            is_tracking,
+            account_class,
         }
     }
 }
 
 impl fmt::Display for DifferenceKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} account for {}", self.account_class, self.currency,)
+    }
+}
+
+impl fmt::Display for AccountClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{} account for {}",
-            if self.is_tracking {
-                "tracking"
-            } else {
-                "budget"
-            },
-            self.currency
+            "{}",
+            match self {
+                AccountClass::Debit => "debit",
+                AccountClass::Credit => "credit",
+                AccountClass::Tracking => "tracking",
+            }
         )
     }
 }


### PR DESCRIPTION
This seems to address the weirdness with the starting balance when opening a new credit card account.  In my initial testing everything else seems to flow through properly (when you make a charge or payment to the real CC account, that change is properly reflected in the difference account and the new "Credit Card Payments" budget category for the difference account).

This definitely needs more thorough testing and real-world use before releasing, and the documentation also needs to be updated.