### PR TITLE
Round adjustment transactions to budget's decimal digits (fixes #23)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -135,7 +135,6 @@ impl Milliunits {
         )
     }
 
-    /* UNUSED FUNCTIONS
     pub fn abs(&self) -> Milliunits {
         let result = Milliunits(self.0.abs());
         assert_eq!(result.0.scale(), Self::SCALE);
@@ -153,6 +152,7 @@ impl Milliunits {
         )
     }
 
+    /* UNUSED FUNCTIONS
     pub fn round_half_up(self, currency_decimal_digits: u32) -> Milliunits {
         self.round_dp_with_strategy(currency_decimal_digits, RoundingStrategy::RoundHalfUp)
     }
@@ -348,7 +348,6 @@ mod tests {
         );
     }
 
-    /* UNUSED FUNCTIONS
     #[test]
     fn test_milliunits_smallest_unit() {
         assert_eq!(
@@ -365,5 +364,4 @@ mod tests {
         );
         assert_eq!(Milliunits::smallest_unit(3), Milliunits::from_scaled_i64(1));
     }
-    */
 }


### PR DESCRIPTION
@wizonesolutions I believe this will prevent "cycles" like you experienced.  When I fixed #8, I tried to be smart and have adjustment transactions fix difference accounts with non-zero-sub-cent balances by ensuring the final balance would be properly rounded.  This required creating a non-zero-sub-cent transaction in order to do so.  But it looks like that backfired in your case and it's clear that we simply can't trust the numbers coming out of the YNAB API if there are any non-zero-sub-cent values.  Therefore, with this change we will no longer do that, and there is no longer any case where this tool will create a non-zero-sub-cent transaction.  